### PR TITLE
Implement "Build Your Text Editor With Rust, Part 2"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,17 @@
 use crossterm::terminal;
 use std::io::{self, Read};
 
+struct CleanUp;
+
+impl Drop for CleanUp {
+    fn drop(&mut self) {
+        terminal::disable_raw_mode().expect("Could not disable raw mode");
+    }
+}
+
 fn main() {
+    let _clean_up = CleanUp;
+
     terminal::enable_raw_mode().expect("Could not turn on raw mode");
 
     let mut buf = [0; 1];

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,13 +18,13 @@ fn main() -> crossterm::Result<()> {
     loop {
         if event::poll(Duration::from_millis(500))? {
             if let Event::Key(event) = event::read()? {
-                match event {
-                    KeyEvent {
-                        code: KeyCode::Char('q'),
-                        modifiers: event::KeyModifiers::NONE,
-                        ..
-                    } => break,
-                    _ => {}
+                if let KeyEvent {
+                    code: KeyCode::Char('q'),
+                    modifiers: event::KeyModifiers::NONE,
+                    ..
+                } = event
+                {
+                    break;
                 }
 
                 println!("{:?}\r", event);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+use std::io::{self, Read};
+
 fn main() {
-    println!("Hello, world!");
+    let mut buf = [0; 1];
+
+    while io::stdin().read(&mut buf).expect("Failed to read line") == 1 {}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
+use crossterm::terminal;
 use std::io::{self, Read};
 
 fn main() {
+    terminal::enable_raw_mode().expect("Could not turn on raw mode");
+
     let mut buf = [0; 1];
 
     while io::stdin().read(&mut buf).expect("Failed to read line") == 1 && buf != [b'q'] {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,14 +10,14 @@ impl Drop for CleanUp {
     }
 }
 
-fn main() {
+fn main() -> crossterm::Result<()> {
     let _clean_up = CleanUp;
 
-    terminal::enable_raw_mode().expect("Could not turn on raw mode");
+    terminal::enable_raw_mode()?;
 
     loop {
-        if event::poll(Duration::from_millis(500)).expect("Error") {
-            if let Event::Key(event) = event::read().expect("Failed to read line") {
+        if event::poll(Duration::from_millis(500))? {
+            if let Event::Key(event) = event::read()? {
                 match event {
                     KeyEvent {
                         code: KeyCode::Char('q'),
@@ -33,4 +33,6 @@ fn main() {
             println!("No input yet\r");
         }
     }
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use crossterm::terminal;
-use std::io::{self, Read};
+use crossterm::event::{Event, KeyCode, KeyEvent};
+use crossterm::{event, terminal};
 
 struct CleanUp;
 
@@ -14,15 +14,18 @@ fn main() {
 
     terminal::enable_raw_mode().expect("Could not turn on raw mode");
 
-    let mut buf = [0; 1];
+    loop {
+        if let Event::Key(event) = event::read().expect("Failed to read line") {
+            match event {
+                KeyEvent {
+                    code: KeyCode::Char('q'),
+                    modifiers: event::KeyModifiers::NONE,
+                    ..
+                } => break,
+                _ => {}
+            }
 
-    while io::stdin().read(&mut buf).expect("Failed to read line") == 1 && buf != [b'q'] {
-        let character = buf[0] as char;
-
-        if character.is_control() {
-            println!("{}\r", character as u8);
-        } else {
-            println!("{}\r", character);
-        }
+            println!("{:?}\r", event);
+        };
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,5 +16,13 @@ fn main() {
 
     let mut buf = [0; 1];
 
-    while io::stdin().read(&mut buf).expect("Failed to read line") == 1 && buf != [b'q'] {}
+    while io::stdin().read(&mut buf).expect("Failed to read line") == 1 && buf != [b'q'] {
+        let character = buf[0] as char;
+
+        if character.is_control() {
+            println!("{}\r", character as u8);
+        } else {
+            println!("{}\r", character);
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,5 +3,5 @@ use std::io::{self, Read};
 fn main() {
     let mut buf = [0; 1];
 
-    while io::stdin().read(&mut buf).expect("Failed to read line") == 1 {}
+    while io::stdin().read(&mut buf).expect("Failed to read line") == 1 && buf != [b'q'] {}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use crossterm::event::{Event, KeyCode, KeyEvent};
 use crossterm::{event, terminal};
+use std::time::Duration;
 
 struct CleanUp;
 
@@ -15,17 +16,21 @@ fn main() {
     terminal::enable_raw_mode().expect("Could not turn on raw mode");
 
     loop {
-        if let Event::Key(event) = event::read().expect("Failed to read line") {
-            match event {
-                KeyEvent {
-                    code: KeyCode::Char('q'),
-                    modifiers: event::KeyModifiers::NONE,
-                    ..
-                } => break,
-                _ => {}
-            }
+        if event::poll(Duration::from_millis(500)).expect("Error") {
+            if let Event::Key(event) = event::read().expect("Failed to read line") {
+                match event {
+                    KeyEvent {
+                        code: KeyCode::Char('q'),
+                        modifiers: event::KeyModifiers::NONE,
+                        ..
+                    } => break,
+                    _ => {}
+                }
 
-            println!("{:?}\r", event);
-        };
+                println!("{:?}\r", event);
+            };
+        } else {
+            println!("No input yet\r");
+        }
     }
 }


### PR DESCRIPTION
This revision includes:
- Implement "Build Your Text Editor With Rust, Part 2"
  - Press q To Quit
  - Canonical and Raw Mode
  - Enable Raw Mode
  - Disable Raw Mode
  - Display Keypresses
  - Migrating Project To Use crossterm
  - Timeout for `read()`
  - Error handling