### PR TITLE
Implement "Build Your Text Editor With Rust, Part 3"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ struct CleanUp;
 impl Drop for CleanUp {
     fn drop(&mut self) {
         terminal::disable_raw_mode().expect("Could not disable raw mode");
+        Output::clear_screen().expect("Error");
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,29 +10,54 @@ impl Drop for CleanUp {
     }
 }
 
+struct Reader;
+
+impl Reader {
+    fn read_key(&self) -> crossterm::Result<KeyEvent> {
+        loop {
+            if event::poll(Duration::from_millis(500))? {
+                if let Event::Key(event) = event::read()? {
+                    return Ok(event);
+                }
+            }
+        }
+    }
+}
+
+struct Editor {
+    reader: Reader,
+}
+
+impl Editor {
+    fn new() -> Self {
+        Self { reader: Reader }
+    }
+
+    fn process_key_press(&self) -> crossterm::Result<bool> {
+        match self.reader.read_key()? {
+            KeyEvent {
+                code: KeyCode::Char('q'),
+                modifiers: event::KeyModifiers::CONTROL,
+                ..
+            } => return Ok(false),
+            _ => {}
+        }
+
+        Ok(true)
+    }
+
+    fn run(&self) -> crossterm::Result<bool> {
+        self.process_key_press()
+    }
+}
+
 fn main() -> crossterm::Result<()> {
     let _clean_up = CleanUp;
 
     terminal::enable_raw_mode()?;
 
-    loop {
-        if event::poll(Duration::from_millis(1000))? {
-            if let Event::Key(event) = event::read()? {
-                if let KeyEvent {
-                    code: KeyCode::Char('q'),
-                    modifiers: event::KeyModifiers::CONTROL,
-                    ..
-                } = event
-                {
-                    break;
-                }
-
-                println!("{:?}\r", event);
-            };
-        } else {
-            println!("No input yet\r");
-        }
-    }
+    let editor = Editor::new();
+    while editor.run()? {}
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use crossterm::event::*;
 use crossterm::terminal::ClearType;
-use crossterm::{cursor, execute, terminal};
-use std::io::{stdout, Write};
+use crossterm::{cursor, execute, queue, terminal};
+use std::io::{self, stdout, Write};
 use std::time::Duration;
 
 struct CleanUp;
@@ -27,8 +27,50 @@ impl Reader {
     }
 }
 
+struct EditorContents {
+    content: String,
+}
+
+impl EditorContents {
+    fn new() -> Self {
+        Self {
+            content: String::new(),
+        }
+    }
+
+    fn push(&mut self, ch: char) {
+        self.content.push(ch)
+    }
+
+    fn push_str(&mut self, string: &str) {
+        self.content.push_str(string)
+    }
+}
+
+impl Write for EditorContents {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match std::str::from_utf8(buf) {
+            Ok(s) => {
+                self.content.push_str(s);
+                Ok(s.len())
+            }
+            Err(_) => Err(io::ErrorKind::WriteZero.into()),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let out = write!(stdout(), "{}", self.content);
+
+        stdout().flush()?;
+        self.content.clear();
+
+        out
+    }
+}
+
 struct Output {
     win_size: (usize, usize),
+    editor_contents: EditorContents,
 }
 
 impl Output {
@@ -37,7 +79,10 @@ impl Output {
             .map(|(x, y)| (x as usize, y as usize))
             .unwrap();
 
-        Self { win_size }
+        Self {
+            win_size,
+            editor_contents: EditorContents::new(),
+        }
     }
 
     fn clear_screen() -> crossterm::Result<()> {
@@ -45,24 +90,27 @@ impl Output {
         execute!(stdout(), cursor::MoveTo(0, 0))
     }
 
-    fn draw_rows(&self) {
+    fn draw_rows(&mut self) {
         let screen_rows = self.win_size.1;
 
         for i in 0..screen_rows {
-            print!("~");
+            self.editor_contents.push('~');
 
             if i < screen_rows - 1 {
-                println!("\r");
+                self.editor_contents.push_str("\r\n");
             }
-
-            stdout().flush().unwrap();
         }
     }
 
-    fn refresh_screen(&self) -> crossterm::Result<()> {
-        Self::clear_screen()?;
+    fn refresh_screen(&mut self) -> crossterm::Result<()> {
+        queue!(
+            self.editor_contents,
+            terminal::Clear(ClearType::All),
+            cursor::MoveTo(0, 0)
+        )?;
         self.draw_rows();
-        execute!(stdout(), cursor::MoveTo(0, 0))
+        queue!(self.editor_contents, cursor::MoveTo(0, 0))?;
+        self.editor_contents.flush()
     }
 }
 
@@ -92,7 +140,7 @@ impl Editor {
         Ok(true)
     }
 
-    fn run(&self) -> crossterm::Result<bool> {
+    fn run(&mut self) -> crossterm::Result<bool> {
         self.output.refresh_screen()?;
         self.process_key_press()
     }
@@ -103,7 +151,7 @@ fn main() -> crossterm::Result<()> {
 
     terminal::enable_raw_mode()?;
 
-    let editor = Editor::new();
+    let mut editor = Editor::new();
     while editor.run()? {}
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use crossterm::event::*;
 use crossterm::terminal::ClearType;
-use crossterm::{execute, terminal};
+use crossterm::{cursor, execute, terminal};
 use std::io::stdout;
 use std::time::Duration;
 
@@ -34,7 +34,8 @@ impl Output {
     }
 
     fn clear_screen() -> crossterm::Result<()> {
-        execute!(stdout(), terminal::Clear(ClearType::All))
+        execute!(stdout(), terminal::Clear(ClearType::All))?;
+        execute!(stdout(), cursor::MoveTo(0, 0))
     }
 
     fn refresh_screen(&self) -> crossterm::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,11 +105,12 @@ impl Output {
     fn refresh_screen(&mut self) -> crossterm::Result<()> {
         queue!(
             self.editor_contents,
+            cursor::Hide,
             terminal::Clear(ClearType::All),
             cursor::MoveTo(0, 0)
         )?;
         self.draw_rows();
-        queue!(self.editor_contents, cursor::MoveTo(0, 0))?;
+        queue!(self.editor_contents, cursor::MoveTo(0, 0), cursor::Show)?;
         self.editor_contents.flush()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use crossterm::event::*;
 use crossterm::terminal::ClearType;
 use crossterm::{cursor, execute, terminal};
-use std::io::stdout;
+use std::io::{stdout, Write};
 use std::time::Duration;
 
 struct CleanUp;
@@ -48,8 +48,14 @@ impl Output {
     fn draw_rows(&self) {
         let screen_rows = self.win_size.1;
 
-        for _ in 0..screen_rows {
-            println!("~\r");
+        for i in 0..screen_rows {
+            print!("~");
+
+            if i < screen_rows - 1 {
+                println!("\r");
+            }
+
+            stdout().flush().unwrap();
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,11 +16,11 @@ fn main() -> crossterm::Result<()> {
     terminal::enable_raw_mode()?;
 
     loop {
-        if event::poll(Duration::from_millis(500))? {
+        if event::poll(Duration::from_millis(1000))? {
             if let Event::Key(event) = event::read()? {
                 if let KeyEvent {
                     code: KeyCode::Char('q'),
-                    modifiers: event::KeyModifiers::NONE,
+                    modifiers: event::KeyModifiers::CONTROL,
                     ..
                 } = event
                 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,8 @@ impl CursorController {
                     self.cursor_x += 1;
                 }
             }
+            KeyCode::Home => self.cursor_x = 0,
+            KeyCode::End => self.cursor_x = self.screen_columns - 1,
             _ => unimplemented!(),
         }
     }
@@ -214,10 +216,27 @@ impl Editor {
                 ..
             } => return Ok(false),
             KeyEvent {
-                code: direction @ (KeyCode::Up | KeyCode::Down | KeyCode::Left | KeyCode::Right),
+                code:
+                    direction @ (KeyCode::Up
+                    | KeyCode::Down
+                    | KeyCode::Left
+                    | KeyCode::Right
+                    | KeyCode::Home
+                    | KeyCode::End),
                 modifiers: KeyModifiers::NONE,
                 ..
             } => self.output.move_cursor(direction),
+            KeyEvent {
+                code: val @ (KeyCode::PageUp | KeyCode::PageDown),
+                modifiers: KeyModifiers::NONE,
+                ..
+            } => (0..self.output.win_size.1).for_each(|_| {
+                self.output.move_cursor(if matches!(val, KeyCode::PageUp) {
+                    KeyCode::Up
+                } else {
+                    KeyCode::Down
+                });
+            }),
             _ => {}
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,18 +83,18 @@ impl CursorController {
         }
     }
 
-    fn move_cursor(&mut self, direction: char) {
+    fn move_cursor(&mut self, direction: KeyCode) {
         match direction {
-            'w' => {
+            KeyCode::Up => {
                 self.cursor_y -= 1;
             }
-            'a' => {
+            KeyCode::Left => {
                 self.cursor_x -= 1;
             }
-            's' => {
+            KeyCode::Down => {
                 self.cursor_y += 1;
             }
-            'd' => {
+            KeyCode::Right => {
                 self.cursor_x += 1;
             }
             _ => unimplemented!(),
@@ -176,7 +176,7 @@ impl Output {
         self.editor_contents.flush()
     }
 
-    fn move_cursor(&mut self, direction: char) {
+    fn move_cursor(&mut self, direction: KeyCode) {
         self.cursor_controller.move_cursor(direction);
     }
 }
@@ -202,13 +202,10 @@ impl Editor {
                 ..
             } => return Ok(false),
             KeyEvent {
-                code: KeyCode::Char(val),
+                code: direction @ (KeyCode::Up | KeyCode::Down | KeyCode::Left | KeyCode::Right),
                 modifiers: KeyModifiers::NONE,
                 ..
-            } => match val {
-                'w' | 'a' | 's' | 'd' => self.output.move_cursor(val),
-                _ => {}
-            },
+            } => self.output.move_cursor(direction),
             _ => {}
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,11 +27,17 @@ impl Reader {
     }
 }
 
-struct Output;
+struct Output {
+    win_size: (usize, usize),
+}
 
 impl Output {
     fn new() -> Self {
-        Self
+        let win_size = terminal::size()
+            .map(|(x, y)| (x as usize, y as usize))
+            .unwrap();
+
+        Self { win_size }
     }
 
     fn clear_screen() -> crossterm::Result<()> {
@@ -39,8 +45,18 @@ impl Output {
         execute!(stdout(), cursor::MoveTo(0, 0))
     }
 
+    fn draw_rows(&self) {
+        let screen_rows = self.win_size.1;
+
+        for _ in 0..screen_rows {
+            println!("~\r");
+        }
+    }
+
     fn refresh_screen(&self) -> crossterm::Result<()> {
-        Self::clear_screen()
+        Self::clear_screen()?;
+        self.draw_rows();
+        execute!(stdout(), cursor::MoveTo(0, 0))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,11 @@ impl Output {
 
         for i in 0..screen_rows {
             self.editor_contents.push('~');
+            queue!(
+                self.editor_contents,
+                terminal::Clear(ClearType::UntilNewLine)
+            )
+            .unwrap();
 
             if i < screen_rows - 1 {
                 self.editor_contents.push_str("\r\n");
@@ -103,12 +108,7 @@ impl Output {
     }
 
     fn refresh_screen(&mut self) -> crossterm::Result<()> {
-        queue!(
-            self.editor_contents,
-            cursor::Hide,
-            terminal::Clear(ClearType::All),
-            cursor::MoveTo(0, 0)
-        )?;
+        queue!(self.editor_contents, cursor::Hide, cursor::MoveTo(0, 0))?;
         self.draw_rows();
         queue!(self.editor_contents, cursor::MoveTo(0, 0), cursor::Show)?;
         self.editor_contents.flush()

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ use crossterm::{cursor, execute, queue, terminal};
 use std::io::{self, stdout, Write};
 use std::time::Duration;
 
+const VERSION: &str = "0.0.1";
+
 struct CleanUp;
 
 impl Drop for CleanUp {
@@ -91,10 +93,29 @@ impl Output {
     }
 
     fn draw_rows(&mut self) {
-        let screen_rows = self.win_size.1;
+        let (screen_columns, screen_rows) = self.win_size;
 
         for i in 0..screen_rows {
-            self.editor_contents.push('~');
+            if i == screen_rows / 3 {
+                let mut welcome = format!("Texminal Editor --- Version {}", VERSION);
+
+                if welcome.len() > screen_columns {
+                    welcome.truncate(screen_columns)
+                }
+
+                let mut padding = (screen_columns - welcome.len()) / 2;
+
+                if padding != 0 {
+                    self.editor_contents.push_str("~");
+                    padding -= 1;
+                }
+
+                (0..padding).for_each(|_| self.editor_contents.push(' '));
+                self.editor_contents.push_str(&welcome);
+            } else {
+                self.editor_contents.push('~');
+            }
+
             queue!(
                 self.editor_contents,
                 terminal::Clear(ClearType::UntilNewLine)


### PR DESCRIPTION
This revision includes:
- Implement "Build Your Text Editor With Rust, Part 3"
  - Using `Ctrl + Q` to exit
  - Refactor Keyboard Input
  - Clear The Screen
  - Reposition The Cursor
  - Clear Screen On Exit
  - Tildes
  - The Last Line
  - Append Buffer
  - Hide The Cursor When Repainting
  - Clear Lines One At A Time
  - Welcome Message
  - Move The Cursor
  - Move Cursor With Arrow Keys
  - Fix The Out Of Bounds Error
  - Page Up, Page Down, Home And End